### PR TITLE
MUIによるUI調整

### DIFF
--- a/app/components/FeedbackCard.tsx
+++ b/app/components/FeedbackCard.tsx
@@ -11,12 +11,7 @@ export default function FeedbackCard({
 }: FeedbackCardProps) {
   return (
     <Box border={1} borderColor="gainsboro" padding={3} marginBottom={2}>
-      <Typography
-        component="h2"
-        paddingLeft="0px"
-        textAlign="left"
-        fontSize="13px"
-      >
+      <Typography component="h2" textAlign="left" fontSize="13px">
         {comment}
       </Typography>
       <Typography fontSize="10px">

--- a/app/components/FeedbackCard.tsx
+++ b/app/components/FeedbackCard.tsx
@@ -1,0 +1,27 @@
+import { Box, Typography } from "@mui/material";
+
+interface FeedbackCardProps {
+  comment: string;
+  createdAt: string;
+}
+
+export default function FeedbackCard({
+  comment,
+  createdAt,
+}: FeedbackCardProps) {
+  return (
+    <Box border={1} borderColor="gainsboro" padding={3} marginBottom={2}>
+      <Typography
+        component="h2"
+        paddingLeft="0px"
+        textAlign="left"
+        fontSize="13px"
+      >
+        {comment}
+      </Typography>
+      <Typography fontSize="10px">
+        {new Date(createdAt).toLocaleString()}
+      </Typography>
+    </Box>
+  );
+}

--- a/app/components/FeedbackCard.tsx
+++ b/app/components/FeedbackCard.tsx
@@ -1,14 +1,12 @@
 import { Box, Typography } from "@mui/material";
+import { FC } from "react";
 
-interface FeedbackCardProps {
+type FeedbackCardProps = {
   comment: string;
   createdAt: string;
-}
+};
 
-export default function FeedbackCard({
-  comment,
-  createdAt,
-}: FeedbackCardProps) {
+const FeedbackCard: React.FC<FeedbackCardProps> = ({ comment, createdAt }) => {
   return (
     <Box border={1} borderColor="gainsboro" padding={3} marginBottom={2}>
       <Typography component="h2" textAlign="left" fontSize="13px">
@@ -19,4 +17,6 @@ export default function FeedbackCard({
       </Typography>
     </Box>
   );
-}
+};
+
+export default FeedbackCard;

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,6 +1,5 @@
 import { AppBar, Box, Toolbar, Typography } from "@mui/material";
-
-const Header = () => {
+export default function Header() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -17,5 +16,4 @@ const Header = () => {
       </AppBar>
     </Box>
   );
-};
-export default Header;
+}

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -1,54 +1,48 @@
 import Link from "next/link";
 import fetchALLFeedbacks from "../hooks/useFeedback";
 import { PostType } from "../types";
-import { Card, CardContent, Container, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Typography,
+} from "@mui/material";
 
 export default async function Home() {
   const feedbacks = await fetchALLFeedbacks();
   return (
     <Container>
-      <Typography>
-        <h1>欅祭アンケート</h1>
+      <Typography fontSize={80} display="flex" justifyContent="center">
+        欅祭アンケート
       </Typography>
       {/* Link */}
 
-      <Link href={"/feedback"}>
-        <Typography>ブログ新規作成</Typography>
-      </Link>
-
-      <Typography>
+      <div>
         {feedbacks?.map((feedback: PostType) => (
-          <Typography style={{ marginBottom: "60px" }} key={feedback.id}>
-            <Card
-              sx={{
-                border: "2px solid darkgray ",
-                boxShadow: "none",
-                borderRadius: "8px",
-                "&:hover": {
-                  boxShadow: "0px 4px 20px rgba(0,0,0,0.15)",
-                },
-              }}
+          // <FeedBackCard comment={feedback.comment} createdAt={feedback.cre} />
+          <Box
+            border={1}
+            borderColor="gainsboro"
+            padding={3}
+            marginBottom={2}
+            key={feedback.id}
+          >
+            <Typography
+              component="h2"
+              paddingLeft="0px"
+              textAlign="left"
+              fontSize="13px"
             >
-              <CardContent>
-                <Typography
-                  variant="h6"
-                  component="h2"
-                  sx={{
-                    paddingLeft: "0px",
-                    textAlign: "left",
-                    fontWeight: "bold",
-                  }}
-                >
-                  {feedback.comment}
-                </Typography>
-                <Typography fontSize="13px" sx={{ paddingLeft: "0" }}>
-                  {new Date(feedback.createdAt).toLocaleString()}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Typography>
+              {feedback.comment}
+            </Typography>
+            <Typography fontSize="10px">
+              {new Date(feedback.createdAt).toLocaleString()}
+            </Typography>
+          </Box>
         ))}
-      </Typography>
+      </div>
     </Container>
   );
 }

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -1,33 +1,54 @@
 import Link from "next/link";
 import fetchALLFeedbacks from "../hooks/useFeedback";
 import { PostType } from "../types";
+import { Card, CardContent, Container, Typography } from "@mui/material";
 
 export default async function Home() {
   const feedbacks = await fetchALLFeedbacks();
   return (
-    <main>
-      <div>
+    <Container>
+      <Typography>
         <h1>欅祭アンケート</h1>
-      </div>
+      </Typography>
       {/* Link */}
-      <div>
-        <Link href={"/feedback"}>ブログ新規作成</Link>
-      </div>
 
-      <div>
+      <Link href={"/feedback"}>
+        <Typography>ブログ新規作成</Typography>
+      </Link>
+
+      <Typography>
         {feedbacks?.map((feedback: PostType) => (
-          <div key={feedback.id}>
-            <div>
-              <h2>{feedback.comment}</h2>
-            </div>
-            <div>
-              <blockquote>
-                {new Date(feedback.createdAt).toLocaleString()}
-              </blockquote>
-            </div>
-          </div>
+          <Typography style={{ marginBottom: "60px" }} key={feedback.id}>
+            <Card
+              sx={{
+                border: "2px solid darkgray ",
+                boxShadow: "none",
+                borderRadius: "8px",
+                "&:hover": {
+                  boxShadow: "0px 4px 20px rgba(0,0,0,0.15)",
+                },
+              }}
+            >
+              <CardContent>
+                <Typography
+                  variant="h6"
+                  component="h2"
+                  sx={{
+                    paddingLeft: "0px",
+                    textAlign: "left",
+                    fontWeight: "bold",
+                  }}
+                >
+                  {feedback.comment}
+                </Typography>
+                <Typography fontSize="13px" sx={{ paddingLeft: "0" }}>
+                  {new Date(feedback.createdAt).toLocaleString()}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Typography>
         ))}
-      </div>
-    </main>
+      </Typography>
+    </Container>
   );
 }

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -1,48 +1,26 @@
-import Link from "next/link";
 import fetchALLFeedbacks from "../hooks/useFeedback";
 import { PostType } from "../types";
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  Typography,
-} from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
+import FeedbackCard from "./FeedbackCard";
 
 export default async function Home() {
   const feedbacks = await fetchALLFeedbacks();
   return (
     <Container>
-      <Typography fontSize={80} display="flex" justifyContent="center">
+      <Typography fontSize={40} display="flex" justifyContent="center">
         欅祭アンケート
       </Typography>
       {/* Link */}
 
-      <div>
+      <Box>
         {feedbacks?.map((feedback: PostType) => (
-          // <FeedBackCard comment={feedback.comment} createdAt={feedback.cre} />
-          <Box
-            border={1}
-            borderColor="gainsboro"
-            padding={3}
-            marginBottom={2}
+          <FeedbackCard
+            comment={feedback.comment}
+            createdAt={feedback.createdAt}
             key={feedback.id}
-          >
-            <Typography
-              component="h2"
-              paddingLeft="0px"
-              textAlign="left"
-              fontSize="13px"
-            >
-              {feedback.comment}
-            </Typography>
-            <Typography fontSize="10px">
-              {new Date(feedback.createdAt).toLocaleString()}
-            </Typography>
-          </Box>
+          />
         ))}
-      </div>
+      </Box>
     </Container>
   );
 }


### PR DESCRIPTION
@yusei53 
# やったこと
- 　MUIで投稿をカードにして表示
- 　コメントと時刻のフォントを変更
- 　タグ書き換え
# やってないこと
- タイトルの「欅祭アンケート」のUI
- 同じくブログ新規作成リンクのUI
- ヘッダータグのUI
- 新規コメント欄をHOMEに追加
# UI(PC)
<img width="1440" alt="スクリーンショット 2024-08-16 14 03 28" src="https://github.com/user-attachments/assets/47b12f43-31f9-4633-ae19-f12783615239">

<img width="1440" alt="スクリーンショット 2024-08-16 14 03 20" src="https://github.com/user-attachments/assets/c23ae844-245d-46a0-b020-dfc76bf49f51">

# UI(スマートフォン)※最新画像追加しました
<img width="1440" alt="スクリーンショット 2024-08-16 14 21 59" src="https://github.com/user-attachments/assets/8381bc48-0d53-433c-9283-3044a4e94003">
<img width="1440" alt="スクリーンショット 2024-08-16 14 21 56" src="https://github.com/user-attachments/assets/081be1bd-1e0d-4841-969e-934d8025eb6c">
<img width="1440" alt="スクリーンショット 2024-08-16 14 21 52" src="https://github.com/user-attachments/assets/7d53f087-9a70-4cd3-9859-df35a66c386e">
<img width="1440" alt="スクリーンショット 2024-08-16 14 10 13" src="https://github.com/user-attachments/assets/dd0568a4-2906-47dc-9f7e-5d7864c219f9">


# コード
<img width="1440" alt="スクリーンショット 2024-08-16 14 04 15" src="https://github.com/user-attachments/assets/cb3c9d1f-2866-4e95-b1cc-2095c4e2672e">


確認お願いします。
